### PR TITLE
Fix JSON.parse to use response.body

### DIFF
--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -262,9 +262,9 @@ module CreateSend
     def handle_response(response) # :nodoc:
       case response.code
       when 400
-        raise BadRequest.new(Hashie::Mash.new(JSON.parse(response)))
+        raise BadRequest.new(Hashie::Mash.new(JSON.parse(response.body)))
       when 401
-        data = Hashie::Mash.new(JSON.parse(response))
+        data = Hashie::Mash.new(JSON.parse(response.body))
         case data.Code
         when 120
           raise InvalidOAuthToken.new data

--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -262,7 +262,7 @@ module CreateSend
     def handle_response(response) # :nodoc:
       case response.code
       when 400
-        raise BadRequest.new(Hashie::Mash.new response)
+        raise BadRequest.new(Hashie::Mash.new(JSON.parse(response)))
       when 401
         data = Hashie::Mash.new(JSON.parse(response))
         case data.Code


### PR DESCRIPTION
Use `response.body` in `JSON.parse`.

Should fix https://github.com/Crowd9/Gleam/issues/15328

Also added fix for 400s as suggested by @ponny: https://github.com/Crowd9/Gleam/pull/15137#pullrequestreview-669693635